### PR TITLE
track autonat peer addresses

### DIFF
--- a/autonat_test.go
+++ b/autonat_test.go
@@ -73,7 +73,7 @@ func newDialResponseError(status pb.Message_ResponseStatus, text string) *pb.Mes
 func makeAutoNAT(ctx context.Context, t *testing.T, ash host.Host) (host.Host, AutoNAT) {
 	h := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	a := NewAutoNAT(ctx, h, nil)
-	a.(*AmbientAutoNAT).peers[ash.ID()] = struct{}{}
+	a.(*AmbientAutoNAT).peers[ash.ID()] = ash.Addrs()
 
 	return h, a
 }

--- a/notify.go
+++ b/notify.go
@@ -32,7 +32,7 @@ func (as *AmbientAutoNAT) Connected(net inet.Network, c inet.Conn) {
 		if len(protos) > 0 {
 			log.Infof("Discovered AutoNAT peer %s", p.Pretty())
 			as.mx.Lock()
-			as.peers[p] = struct{}{}
+			as.peers[p] = as.host.Peerstore().Addrs(p)
 			as.mx.Unlock()
 		}
 	}()


### PR DESCRIPTION
This patch tracks the autonat peer addresses so that we can still connect to them after we've disconnected once and potentially gc'ed their addresses in the peerstore.
This adds reliability for non-bootstrapper autonat peers.