### PR TITLE
parallelize dialbacks

### DIFF
--- a/autonat.go
+++ b/autonat.go
@@ -158,6 +158,8 @@ func (as *AmbientAutoNAT) autodetect() {
 	for _, pi := range peers[:probe] {
 		wg.Add(1)
 		go func(pi pstore.PeerInfo) {
+			defer wg.Done()
+
 			as.host.Peerstore().AddAddrs(pi.ID, pi.Addrs, pstore.TempAddrTTL)
 			a, err := cli.DialBack(ctx, pi.ID)
 
@@ -178,8 +180,6 @@ func (as *AmbientAutoNAT) autodetect() {
 			default:
 				log.Debugf("Dialback error through %s: %s", pi.ID.Pretty(), err)
 			}
-
-			wg.Done()
 		}(pi)
 	}
 

--- a/autonat.go
+++ b/autonat.go
@@ -206,11 +206,13 @@ func (as *AmbientAutoNAT) autodetect() {
 		}
 		as.status = NATStatusPrivate
 		as.addr = nil
+	} else if as.confidence > 0 {
+		// don't just flip to unknown, reduce confidence first
+		as.confidence--
 	} else {
 		log.Debugf("NAT status is unknown")
 		as.status = NATStatusUnknown
 		as.addr = nil
-		as.confidence = 0
 	}
 	as.mx.Unlock()
 }

--- a/autonat.go
+++ b/autonat.go
@@ -189,6 +189,7 @@ func (as *AmbientAutoNAT) autodetect() {
 	if result.public > 0 {
 		log.Debugf("NAT status is public")
 		if as.status == NATStatusPrivate {
+			// we are flipping our NATStatus, so confidence drops to 0
 			as.confidence = 0
 		} else if as.confidence < 3 {
 			as.confidence++
@@ -198,6 +199,7 @@ func (as *AmbientAutoNAT) autodetect() {
 	} else if result.private > 0 {
 		log.Debugf("NAT status is private")
 		if as.status == NATStatusPublic {
+			// we are flipping our NATStatus, so confidence drops to 0
 			as.confidence = 0
 		} else if as.confidence < 3 {
 			as.confidence++

--- a/autonat.go
+++ b/autonat.go
@@ -186,18 +186,22 @@ func (as *AmbientAutoNAT) autodetect() {
 	as.mx.Lock()
 	if public > 0 {
 		log.Debugf("NAT status is public")
+		if as.status == NATStatusPrivate {
+			as.confidence = 0
+		} else if as.confidence < 3 {
+			as.confidence++
+		}
 		as.status = NATStatusPublic
 		as.addr = pubaddr
-		if as.confidence < 3 {
-			as.confidence++
-		}
 	} else if private > 0 {
 		log.Debugf("NAT status is private")
-		as.status = NATStatusPrivate
-		as.addr = nil
-		if as.confidence < 3 {
+		if as.status == NATStatusPublic {
+			as.confidence = 0
+		} else if as.confidence < 3 {
 			as.confidence++
 		}
+		as.status = NATStatusPrivate
+		as.addr = nil
 	} else {
 		log.Debugf("NAT status is unknown")
 		as.status = NATStatusUnknown

--- a/autonat.go
+++ b/autonat.go
@@ -32,7 +32,7 @@ var (
 	AutoNATBootDelay       = 15 * time.Second
 	AutoNATRetryInterval   = 90 * time.Second
 	AutoNATRefreshInterval = 15 * time.Minute
-	AutoNATRequestTimeout  = 60 * time.Second
+	AutoNATRequestTimeout  = 30 * time.Second
 )
 
 // AutoNAT is the interface for ambient NAT autodiscovery
@@ -135,50 +135,74 @@ func (as *AmbientAutoNAT) autodetect() {
 	}
 
 	cli := NewAutoNATClient(as.host, as.getAddrs)
-	failures := 0
+	ctx, cancel := context.WithTimeout(as.ctx, AutoNATRequestTimeout)
+	defer cancel()
 
-	for _, pi := range peers {
-		ctx, cancel := context.WithTimeout(as.ctx, AutoNATRequestTimeout)
-		as.host.Peerstore().AddAddrs(pi.ID, pi.Addrs, pstore.TempAddrTTL)
-		a, err := cli.DialBack(ctx, pi.ID)
-		cancel()
+	var mx sync.Mutex
+	var pubaddr ma.Multiaddr
+	private := 0
+	public := 0
 
-		switch {
-		case err == nil:
-			log.Debugf("NAT status is public; address through %s: %s", pi.ID.Pretty(), a.String())
-			as.mx.Lock()
-			as.addr = a
-			as.status = NATStatusPublic
-			as.confidence = 0
-			as.mx.Unlock()
-			return
-
-		case IsDialError(err):
-			log.Debugf("dial error through %s: %s", pi.ID.Pretty(), err.Error())
-			failures++
-			if failures >= 3 || as.confidence >= 3 { // 3 times is enemy action
-				log.Debugf("NAT status is private")
-				as.mx.Lock()
-				as.status = NATStatusPrivate
-				as.confidence = 3
-				as.mx.Unlock()
-				return
-			}
-
-		default:
-			log.Debugf("Error dialing through %s: %s", pi.ID.Pretty(), err.Error())
-		}
+	probe := 3 - as.confidence
+	if probe == 0 {
+		probe = 1
+	}
+	if probe > len(peers) {
+		probe = len(peers)
 	}
 
+	var wg sync.WaitGroup
+
+	for _, pi := range peers[:probe] {
+		wg.Add(1)
+		go func(pi pstore.PeerInfo) {
+			as.host.Peerstore().AddAddrs(pi.ID, pi.Addrs, pstore.TempAddrTTL)
+			a, err := cli.DialBack(ctx, pi.ID)
+
+			switch {
+			case err == nil:
+				log.Debugf("Dialback through %s successful; public address is %s", pi.ID.Pretty(), a.String())
+				mx.Lock()
+				public++
+				pubaddr = a
+				mx.Unlock()
+
+			case IsDialError(err):
+				log.Debugf("Dialback through %s failed", pi.ID.Pretty())
+				mx.Lock()
+				private++
+				mx.Unlock()
+
+			default:
+				log.Debugf("Dialback error through %s: %s", pi.ID.Pretty(), err)
+			}
+
+			wg.Done()
+		}(pi)
+	}
+
+	wg.Wait()
+
 	as.mx.Lock()
-	if failures > 0 {
-		as.status = NATStatusPrivate
-		as.confidence++
+	if public > 0 {
+		log.Debugf("NAT status is public")
+		as.status = NATStatusPublic
+		as.addr = pubaddr
+		if as.confidence < 3 {
+			as.confidence++
+		}
+	} else if private > 0 {
 		log.Debugf("NAT status is private")
+		as.status = NATStatusPrivate
+		as.addr = nil
+		if as.confidence < 3 {
+			as.confidence++
+		}
 	} else {
-		as.status = NATStatusUnknown
-		as.confidence = 0
 		log.Debugf("NAT status is unknown")
+		as.status = NATStatusUnknown
+		as.addr = nil
+		as.confidence = 0
 	}
 	as.mx.Unlock()
 }


### PR DESCRIPTION
Dialing multiple autonat peers sequentially unnecessarily slows down NAT autodetection.
This changes the detection logic to perform dialbacks in parallel.

cc @ZenGround0 