### PR TITLE
Add option to force nat into a specified reachability state

### DIFF
--- a/autonat.go
+++ b/autonat.go
@@ -88,6 +88,11 @@ func New(ctx context.Context, h host.Host, options ...Option) (AutoNAT, error) {
 
 	if conf.forceReachability {
 		emitReachabilityChanged.Emit(event.EvtLocalReachabilityChanged{Reachability: conf.reachability})
+
+		// The serice will only exist when reachability is public.
+		if service != nil {
+			service.Enable()
+		}
 		return &StaticAutoNAT{
 			ctx:          ctx,
 			host:         h,

--- a/autonat_test.go
+++ b/autonat_test.go
@@ -232,3 +232,20 @@ func TestAutoNATObservationRecording(t *testing.T) {
 	}
 
 }
+
+func TestStaticNat(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
+	s, _ := h.EventBus().Subscribe(&event.EvtLocalReachabilityChanged{})
+
+	nat, err := New(ctx, h, WithReachability(network.ReachabilityPrivate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nat.Status() != network.ReachabilityPrivate {
+		t.Fatalf("should be private")
+	}
+	expectEvent(t, s, network.ReachabilityPrivate)
+}

--- a/options.go
+++ b/options.go
@@ -12,9 +12,10 @@ import (
 type config struct {
 	host host.Host
 
-	addressFunc AddrFunc
-	dialer      network.Network
-	forceServer bool
+	addressFunc       AddrFunc
+	dialer            network.Network
+	forceReachability bool
+	reachability      network.Reachability
 
 	// client
 	bootDelay       time.Duration
@@ -52,13 +53,22 @@ var defaults = func(c *config) error {
 // make parallel connections, and as such will modify both the associated peerstore
 // and terminate connections of this dialer. The dialer provided
 // should be compatible (TCP/UDP) however with the transports of the libp2p network.
-func EnableService(dialer network.Network, forceServer bool) Option {
+func EnableService(dialer network.Network) Option {
 	return func(c *config) error {
 		if dialer == c.host.Network() || dialer.Peerstore() == c.host.Peerstore() {
 			return errors.New("dialer should not be that of the host")
 		}
 		c.dialer = dialer
-		c.forceServer = forceServer
+		return nil
+	}
+}
+
+// WithReachability overrides autonat to simply report an over-ridden reachability
+// status.
+func WithReachability(reachability network.Reachability) Option {
+	return func(c *config) error {
+		c.forceReachability = true
+		c.reachability = reachability
 		return nil
 	}
 }

--- a/svc.go
+++ b/svc.go
@@ -49,10 +49,6 @@ func newAutoNATService(ctx context.Context, c *config) (*autoNATService, error) 
 		reqs:   make(map[peer.ID]int),
 	}
 
-	if c.forceReachability {
-		as.Enable()
-	}
-
 	return as, nil
 }
 

--- a/svc_test.go
+++ b/svc_test.go
@@ -21,7 +21,7 @@ func makeAutoNATConfig(ctx context.Context, t *testing.T) *config {
 	dh := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	c := config{host: h, dialer: dh.Network()}
 	_ = defaults(&c)
-	c.forceServer = true
+	c.forceReachability = true
 	return &c
 }
 
@@ -195,7 +195,7 @@ func TestAutoNATServiceStartup(t *testing.T) {
 
 	h := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	dh := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
-	an, err := New(ctx, h, EnableService(dh.Network(), false))
+	an, err := New(ctx, h, EnableService(dh.Network()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/svc_test.go
+++ b/svc_test.go
@@ -30,6 +30,7 @@ func makeAutoNATService(ctx context.Context, t *testing.T, c *config) *autoNATSe
 	if err != nil {
 		t.Fatal(err)
 	}
+	as.Enable()
 
 	return as
 }


### PR DESCRIPTION
The more common way we want to expose "don't run autonat" at the libp2p level is probably "force this node to believe it (is/isn't) natted" rather than "don't run the service or report any reachability. The later better decouples the nat subsystem from other systems like DHT or relaying.

ref: https://github.com/libp2p/go-libp2p/issues/845