### PR TITLE
static nat shouldn't call host.Addrs()

### DIFF
--- a/autonat.go
+++ b/autonat.go
@@ -443,9 +443,5 @@ func (s *StaticAutoNAT) PublicAddr() (ma.Multiaddr, error) {
 	if s.reachability != network.ReachabilityPublic {
 		return nil, errors.New("NAT status is not public")
 	}
-	addrs := s.host.Addrs()
-	if len(addrs) > 0 {
-		return s.host.Addrs()[0], nil
-	}
 	return nil, errors.New("No available address")
 }


### PR DESCRIPTION
avoid potential call loop

a code search indicates that publicAddr is only referenced by host.addrs, and as such the back-fill in the 'autonat-not-active' case will not be needed or useful.