### PR TITLE
replace the port number for double NAT mapping

### DIFF
--- a/svc.go
+++ b/svc.go
@@ -127,8 +127,9 @@ func (as *autoNATService) handleDial(p peer.ID, obsaddr ma.Multiaddr, mpi *pb.Me
 			succ, newobsaddr := patchObsaddr(addr, obsaddr)
 			if succ == true {
 				addr = newobsaddr
+			} else {
+				continue
 			}
-			continue
 		}
 
 		if ip, err := manet.ToIP(addr); err != nil || !obsHost.Equal(ip) {

--- a/svc.go
+++ b/svc.go
@@ -235,8 +235,8 @@ func (as *autoNATService) background(ctx context.Context) {
 	}
 }
 
-//replace obsaddr's port number with the port number of a
-func patchObsaddr(a ma.Multiaddr, obsaddr ma.Multiaddr) (bool, ma.Multiaddr) {
+// patchObsaddr replaces obsaddr's port number with the port number of `a`
+func patchObsaddr(a, obsaddr ma.Multiaddr) (bool, ma.Multiaddr) {
 	if a == nil || obsaddr == nil {
 		return false, nil
 	}

--- a/svc_test.go
+++ b/svc_test.go
@@ -207,3 +207,25 @@ func TestAutoNATServiceStartup(t *testing.T) {
 		t.Fatalf("autonat should report public, but didn't")
 	}
 }
+
+func TestMultiaddrPatchSuccess(t *testing.T) {
+	m1, _ := ma.NewMultiaddr("/ip4/192.168.0.10/tcp/64555")
+	m2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/tcp/19005")
+	correctm2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/tcp/64555")
+	succ, newm2 := patchObsaddr(m1, m2)
+	if succ == false {
+		t.Fatalf("patchObsaddr failed, was %s", m2)
+	}
+	if newm2.Equal(correctm2) == false {
+		t.Fatalf("patchObsaddr success, but new obsaddr is %s should be %s", newm2, correctm2)
+	}
+}
+
+func TestMultiaddrPatchError(t *testing.T) {
+	m1, _ := ma.NewMultiaddr("/ip4/192.168.0.10/tcp/64555")
+	m2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/udp/19005")
+	succ, newm2 := patchObsaddr(m1, m2)
+	if succ == true {
+		t.Fatalf("this address should not be patch, new address %s", newm2)
+	}
+}

--- a/svc_test.go
+++ b/svc_test.go
@@ -212,9 +212,9 @@ func TestMultiaddrPatchSuccess(t *testing.T) {
 	m1, _ := ma.NewMultiaddr("/ip4/192.168.0.10/tcp/64555")
 	m2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/tcp/19005")
 	correctm2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/tcp/64555")
-	succ, newm2 := patchObsaddr(m1, m2)
-	if succ == false {
-		t.Fatalf("patchObsaddr failed, was %s", m2)
+	err, newm2 := patchObsaddr(m1, m2)
+	if err != nil {
+		t.Fatalf("patchObsaddr failed, was %s error %s", m2, err)
 	}
 	if newm2.Equal(correctm2) == false {
 		t.Fatalf("patchObsaddr success, but new obsaddr is %s should be %s", newm2, correctm2)
@@ -224,8 +224,8 @@ func TestMultiaddrPatchSuccess(t *testing.T) {
 func TestMultiaddrPatchError(t *testing.T) {
 	m1, _ := ma.NewMultiaddr("/ip4/192.168.0.10/tcp/64555")
 	m2, _ := ma.NewMultiaddr("/ip4/72.53.243.114/udp/19005")
-	succ, newm2 := patchObsaddr(m1, m2)
-	if succ == true {
-		t.Fatalf("this address should not be patch, new address %s", newm2)
+	err, newm2 := patchObsaddr(m1, m2)
+	if err == nil {
+		t.Fatalf("this address should not be patched, new address: %s", newm2)
 	}
 }


### PR DESCRIPTION
This fixed the double-NAT problem.

Scenario:

libp2p listening on port 7000 -> Router A with upnp -> Router B with upnp  -> Internet 

Router A in the DMZ of the Router B. Router A ip range  10.0.0.0-255 Router B ip range  192.168.0.0-255

Router A will add a dynamic port forwarding by upnp, for example, 34372 -> 7000, and Router B will forward port 34372 to Router A.

So we have two addresses:

```/ip4/10.0.0.100/tcp/7000```
```/ip4/192.168.0.100/tcp/34372```

go-libp2p-autonat will try to dialback to ```/ipv4/PUBLIC_IP/tcp/7000``` in this scenario, and it will fail. 

The port 7000 should be replaced with the upnp forwarding port 34372.